### PR TITLE
Update translation key; fix broken `insertBetween`

### DIFF
--- a/js/src/common/applyEditor.js
+++ b/js/src/common/applyEditor.js
@@ -24,12 +24,12 @@ export default function applyEditor() {
 
     items.add(
       'rich-text',
-      <Tooltip text={app.translator.trans('core.lib.composer.preview_tooltip')}>
+      <Tooltip text={app.translator.trans('askvortsov-rich-text.lib.composer.toggle_button')}>
         <Button
           icon="fas fa-pen-fancy"
           className={classList({ Button: true, 'Button--icon': true, active: app.session.user.preferences().useRichTextEditor })}
           onclick={buttonOnClick}
-        ></Button>
+        />
       </Tooltip>,
       -10
     );
@@ -40,7 +40,7 @@ export default function applyEditor() {
 
     items.remove('markdown');
 
-    items.add('prosemirror-menu', <ProseMirrorMenu state={this.menuState}></ProseMirrorMenu>, 100);
+    items.add('prosemirror-menu', <ProseMirrorMenu state={this.menuState} />, 100);
   });
 
   extend(TextEditor.prototype, 'buildEditorParams', function (items) {

--- a/js/src/common/proseMirror/ProseMirrorEditorDriver.js
+++ b/js/src/common/proseMirror/ProseMirrorEditorDriver.js
@@ -182,7 +182,7 @@ export default class ProseMirrorEditorDriver {
    * @param rawMarkdown
    */
   insertBetween(start, end, text, escape = true) {
-    let trailingNewLines;
+    let trailingNewLines = 0;
 
     if (escape) {
       this.view.dispatch(this.view.state.tr.insertText(text, start, end));


### PR DESCRIPTION
Fixes #1, fixes #2, fixes #3.

- Uses the correct translation key for the toggle editor button.
- Implements the fix from #6 for Emoji and Mentions
